### PR TITLE
PHP 8 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.phpcs-cache
 /.phpunit.result.cache
 /clover.xml
 /composer.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,36 +6,30 @@ cache:
 
 env:
   global:
-    - COMPOSER_ARGS="--no-interaction"
+    - COMPOSER_ARGS="--no-interaction --ignore-platform-reqs"
     - COVERAGE_DEPS="php-coveralls/php-coveralls"
 
 matrix:
   fast_finish: true
   include:
-    - php: 7.1
+    - php: 7.3
       env:
         - DEPS=lowest
-    - php: 7.1
+    - php: 7.3
+      env:
+        - DEPS=latest
+    - php: 7.4
+      env:
+        - DEPS=lowest
+    - php: 7.4
       env:
         - DEPS=latest
         - CS_CHECK=true
         - TEST_COVERAGE=true
-    - php: 7.2
+    - php: nightly
       env:
         - DEPS=lowest
-    - php: 7.2
-      env:
-        - DEPS=latest
-    - php: 7.3
-      env:
-        - DEPS=lowest
-    - php: 7.3
-      env:
-        - DEPS=latest
-    - php: 7.4
-      env:
-        - DEPS=lowest
-    - php: 7.4
+    - php: nightly
       env:
         - DEPS=latest
 
@@ -43,8 +37,7 @@ before_install:
   - if [[ $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
 
 install:
-  - travis_retry composer install $COMPOSER_ARGS --ignore-platform-reqs
-  - if [[ $LEGACY_DEPS != '' ]]; then travis_retry composer update $COMPOSER_ARGS --with-dependencies $LEGACY_DEPS ; fi
+  - travis_retry composer install $COMPOSER_ARGS
   - if [[ $DEPS == 'latest' ]]; then travis_retry composer update $COMPOSER_ARGS ; fi
   - if [[ $DEPS == 'lowest' ]]; then travis_retry composer update --prefer-lowest --prefer-stable $COMPOSER_ARGS ; fi
   - if [[ $TEST_COVERAGE == 'true' ]]; then travis_retry composer require --dev $COMPOSER_ARGS $COVERAGE_DEPS ; fi

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         }
     },
     "require": {
-        "php": "^7.1",
+        "php": "^7.3 || ~8.0.0",
         "laminas/laminas-zendframework-bridge": "^1.0",
         "mezzio/mezzio-helpers": "^5.0",
         "mezzio/mezzio-router": "^3.0",
@@ -40,8 +40,7 @@
     "require-dev": {
         "laminas/laminas-coding-standard": "~1.0.0",
         "malukenho/docheader": "^0.1.5",
-        "phpspec/prophecy": "^1.10.3",
-        "phpunit/phpunit": "^7.5.20 || ^8.5.2"
+        "phpunit/phpunit": "^9.3"
     },
     "conflict": {
         "container-interop/container-interop": "<1.2.0"

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "twig/twig": "^1.42.5 || ^2.12.5 || ^3.0.3"
     },
     "require-dev": {
-        "laminas/laminas-coding-standard": "~1.0.0",
+        "laminas/laminas-coding-standard": "~2.1.0",
         "malukenho/docheader": "^0.1.5",
         "phpunit/phpunit": "^9.3"
     },

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,9 +1,23 @@
 <?xml version="1.0"?>
-<ruleset name="Laminas coding standard">
-    <rule ref="./vendor/laminas/laminas-coding-standard/ruleset.xml"/>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/squizlabs/php_codesniffer/phpcs.xsd">
+
+    <arg name="basepath" value="."/>
+    <arg name="cache" value=".phpcs-cache"/>
+    <arg name="colors"/>
+    <arg name="extensions" value="php"/>
+    <arg name="parallel" value="80"/>
+
+    <!-- Show progress -->
+    <arg value="p"/>
 
     <!-- Paths to check -->
     <file>src</file>
     <file>test</file>
-    <exclude-pattern>test/TestAsset/test/test.js</exclude-pattern>
+
+    <!-- Include all rules from the Laminas Coding Standard -->
+    <rule ref="LaminasCodingStandard">
+        <exclude name="WebimpressCodingStandard.PHP.DisallowFqn.ClassAliasUsed"/>
+        <exclude name="WebimpressCodingStandard.PHP.DisallowFqn.FileName"/>
+    </rule>
 </ruleset>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,13 +1,13 @@
-<phpunit bootstrap="./vendor/autoload.php" colors="true">
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" bootstrap="vendor/autoload.php" colors="true">
+    <coverage processUncoveredFiles="true">
+        <include>
+            <directory suffix=".php">./src</directory>
+        </include>
+    </coverage>
     <testsuites>
-        <testsuite name="Mezzio Twig Tests">
+        <testsuite name="mezzio-twigrenderer">
             <directory>./test</directory>
         </testsuite>
     </testsuites>
-
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">src</directory>
-        </whitelist>
-    </filter>
 </phpunit>

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -16,7 +16,7 @@ use Twig_Environment;
 
 class ConfigProvider
 {
-    public function __invoke() : array
+    public function __invoke(): array
     {
         return [
             'dependencies' => $this->getDependencies(),
@@ -24,28 +24,28 @@ class ConfigProvider
         ];
     }
 
-    public function getDependencies() : array
+    public function getDependencies(): array
     {
         return [
             'aliases'   => [
                 TemplateRendererInterface::class => TwigRenderer::class,
-                Twig_Environment::class => Environment::class,
+                Twig_Environment::class          => Environment::class,
 
                 // Legacy Zend Framework aliases
                 \Zend\Expressive\Template\TemplateRendererInterface::class => TemplateRendererInterface::class,
-                \Zend\Expressive\Twig\Twig_Environment::class => Twig_Environment::class,
-                \Zend\Expressive\Twig\TwigExtension::class => TwigExtension::class,
-                \Zend\Expressive\Twig\TwigRenderer::class => TwigRenderer::class,
+                \Zend\Expressive\Twig\Twig_Environment::class              => Twig_Environment::class,
+                \Zend\Expressive\Twig\TwigExtension::class                 => TwigExtension::class,
+                \Zend\Expressive\Twig\TwigRenderer::class                  => TwigRenderer::class,
             ],
             'factories' => [
-                Environment::class => TwigEnvironmentFactory::class,
-                TwigExtension::class    => TwigExtensionFactory::class,
-                TwigRenderer::class     => TwigRendererFactory::class,
+                Environment::class   => TwigEnvironmentFactory::class,
+                TwigExtension::class => TwigExtensionFactory::class,
+                TwigRenderer::class  => TwigRendererFactory::class,
             ],
         ];
     }
 
-    public function getTemplates() : array
+    public function getTemplates(): array
     {
         return [
             'extension' => 'html.twig',

--- a/src/TwigEnvironmentFactory.php
+++ b/src/TwigEnvironmentFactory.php
@@ -73,29 +73,28 @@ use function sprintf;
  * Note: the various keys in the `twig` configuration key can occur in either
  * that location, or under `templates` (which was the behavior prior to 0.3.0);
  * the two arrays are merged by the factory.
+ *
+ * phpcs:disable WebimpressCodingStandard.PHP.DisallowFqn.DirName
  */
 class TwigEnvironmentFactory
 {
     /**
-     * @param ContainerInterface $container
-     *
-     * @return Environment
      * @throws LoaderError
      */
-    public function __invoke(ContainerInterface $container) : Environment
+    public function __invoke(ContainerInterface $container): Environment
     {
         $config = $container->has('config') ? $container->get('config') : [];
 
         if (! is_array($config) && ! $config instanceof ArrayObject) {
             throw new Exception\InvalidConfigException(sprintf(
                 '"config" service must be an array or ArrayObject for the %s to be able to consume it; received %s',
-                __CLASS__,
-                (is_object($config) ? get_class($config) : gettype($config))
+                self::class,
+                is_object($config) ? get_class($config) : gettype($config)
             ));
         }
 
-        $debug    = (bool) ($config['debug'] ?? false);
-        $config   = TwigRendererFactory::mergeConfig($config);
+        $debug  = (bool) ($config['debug'] ?? false);
+        $config = TwigRendererFactory::mergeConfig($config);
 
         // Create the engine instance
         $loader      = new FilesystemLoader();
@@ -122,7 +121,8 @@ class TwigEnvironmentFactory
         }
 
         // Add mezzio twig extension if requirements are met
-        if ($container->has(TwigExtension::class)
+        if (
+            $container->has(TwigExtension::class)
             && $container->has(ServerUrlHelper::class)
             && $container->has(UrlHelper::class)
         ) {
@@ -162,16 +162,12 @@ class TwigEnvironmentFactory
 
     /**
      * Inject extensions into the TwigEnvironment instance.
-     *
-     * @param Environment        $environment
-     * @param ContainerInterface $container
-     * @param array              $extensions
      */
     private function injectExtensions(
         Environment $environment,
         ContainerInterface $container,
         array $extensions
-    ) : void {
+    ): void {
         foreach ($extensions as $extension) {
             $extension = $this->loadExtension($extension, $container);
 
@@ -189,10 +185,6 @@ class TwigEnvironmentFactory
      * If the extension is not an ExtensionInterface, raises an exception.
      *
      * @param string|ExtensionInterface $extension
-     *
-     * @param ContainerInterface        $container
-     *
-     * @return ExtensionInterface
      */
     private function loadExtension($extension, ContainerInterface $container): ExtensionInterface
     {
@@ -214,16 +206,12 @@ class TwigEnvironmentFactory
 
     /**
      * Inject Runtime Loaders into the TwigEnvironment instance.
-     *
-     * @param Environment        $environment
-     * @param ContainerInterface $container
-     * @param array              $runtimes
      */
     private function injectRuntimeLoaders(
         Environment $environment,
         ContainerInterface $container,
         array $runtimes
-    ) : void {
+    ): void {
         foreach ($runtimes as $runtimeLoader) {
             $runtimeLoader = $this->loadRuntimeLoader($runtimeLoader, $container);
             $environment->addRuntimeLoader($runtimeLoader);
@@ -232,10 +220,6 @@ class TwigEnvironmentFactory
 
     /**
      * @param string|RuntimeLoaderInterface $runtimeLoader
-     *
-     * @param ContainerInterface            $container
-     *
-     * @return RuntimeLoaderInterface
      */
     private function loadRuntimeLoader($runtimeLoader, ContainerInterface $container): RuntimeLoaderInterface
     {

--- a/src/TwigExtension.php
+++ b/src/TwigExtension.php
@@ -18,36 +18,25 @@ use Twig\TwigFunction;
 
 /**
  * Twig extension for rendering URLs and assets URLs from Mezzio.
- *
- * @author Geert Eltink (https://xtreamwayz.com)
  */
 class TwigExtension extends AbstractExtension implements GlobalsInterface
 {
-    /**
-     * @var ServerUrlHelper
-     */
+    /** @var ServerUrlHelper */
     private $serverUrlHelper;
 
-    /**
-     * @var UrlHelper
-     */
+    /** @var UrlHelper */
     private $urlHelper;
 
-    /**
-     * @var null|string
-     */
+    /** @var null|string */
     private $assetsUrl;
 
-    /**
-     * @var null|string|int
-     */
+    /** @var null|string|int */
     private $assetsVersion;
 
-    /**
-     * @var array
-     */
+    /** @var array */
     private $globals;
 
+    /** @param null|string|int $assetsVersion */
     public function __construct(
         ServerUrlHelper $serverUrlHelper,
         UrlHelper $urlHelper,
@@ -62,7 +51,7 @@ class TwigExtension extends AbstractExtension implements GlobalsInterface
         $this->globals         = $globals;
     }
 
-    public function getGlobals() : array
+    public function getGlobals(): array
     {
         return $this->globals;
     }
@@ -70,7 +59,7 @@ class TwigExtension extends AbstractExtension implements GlobalsInterface
     /**
      * @return TwigFunction[]
      */
-    public function getFunctions() : array
+    public function getFunctions(): array
     {
         return [
             new TwigFunction('absolute_url', [$this, 'renderUrlFromPath']),
@@ -89,15 +78,9 @@ class TwigExtension extends AbstractExtension implements GlobalsInterface
      * Usage: {{ path('article_show', {'id': '3'}, {'foo': 'bar'}, 'fragment') }}
      * Generates: /article/3?foo=bar#fragment
      *
-     * @param null|string $route
-     * @param array       $routeParams
-     * @param array       $queryParams
-     * @param null|string $fragmentIdentifier
-     * @param array       $options Can have the following keys:
-     *                             - reuse_result_params (bool): indicates if the current
-     *                             RouteResult parameters will be used, defaults to true
-     *
-     * @return string
+     * @param array $options Can have the following keys:
+     *                       - reuse_result_params (bool): indicates if the current
+     *                       RouteResult parameters will be used, defaults to true
      */
     public function renderUri(
         ?string $route = null,
@@ -106,7 +89,6 @@ class TwigExtension extends AbstractExtension implements GlobalsInterface
         ?string $fragmentIdentifier = null,
         array $options = []
     ): string {
-
         return $this->urlHelper->generate($route, $routeParams, $queryParams, $fragmentIdentifier, $options);
     }
 
@@ -119,15 +101,9 @@ class TwigExtension extends AbstractExtension implements GlobalsInterface
      * Usage: {{ url('article_show', {'id': '3'}, {'foo': 'bar'}, 'fragment') }}
      * Generates: http://example.com/article/3?foo=bar#fragment
      *
-     * @param null|string $route
-     * @param array       $routeParams
-     * @param array       $queryParams
-     * @param null|string $fragmentIdentifier
-     * @param array       $options Can have the following keys:
-     *                             - reuse_result_params (bool): indicates if the current
-     *                             RouteResult parameters will be used, defaults to true
-     *
-     * @return string
+     * @param array $options Can have the following keys:
+     *                       - reuse_result_params (bool): indicates if the current
+     *                       RouteResult parameters will be used, defaults to true
      */
     public function renderUrl(
         ?string $route = null,
@@ -136,7 +112,6 @@ class TwigExtension extends AbstractExtension implements GlobalsInterface
         ?string $fragmentIdentifier = null,
         array $options = []
     ): string {
-
         return $this->serverUrlHelper->generate(
             $this->renderUri($route, $routeParams, $queryParams, $fragmentIdentifier, $options)
         );
@@ -147,12 +122,8 @@ class TwigExtension extends AbstractExtension implements GlobalsInterface
      *
      * Usage: {{ absolute_url('path/to/something') }}
      * Generates: http://example.com/path/to/something
-     *
-     * @param string|null $path
-     *
-     * @return string
      */
-    public function renderUrlFromPath(string $path = null) : string
+    public function renderUrlFromPath(?string $path = null): string
     {
         return $this->serverUrlHelper->generate($path);
     }
@@ -162,13 +133,8 @@ class TwigExtension extends AbstractExtension implements GlobalsInterface
      *
      * Usage: {{ asset('path/to/asset/name.ext', version=3) }}
      * Generates: path/to/asset/name.ext?v=3
-     *
-     * @param string      $path
-     * @param string|null $version
-     *
-     * @return string
      */
-    public function renderAssetUrl(string $path, string $version = null) : string
+    public function renderAssetUrl(string $path, ?string $version = null): string
     {
         $assetsVersion = $version !== null && $version !== '' ? $version : $this->assetsVersion;
 

--- a/src/TwigExtensionFactory.php
+++ b/src/TwigExtensionFactory.php
@@ -19,9 +19,10 @@ use function sprintf;
 
 class TwigExtensionFactory
 {
-    public function __invoke(ContainerInterface $container) : TwigExtension
+    public function __invoke(ContainerInterface $container): TwigExtension
     {
-        if (! $container->has(ServerUrlHelper::class)
+        if (
+            ! $container->has(ServerUrlHelper::class)
             && ! $container->has(\Zend\Expressive\Helper\ServerUrlHelper::class)
         ) {
             throw new InvalidConfigException(sprintf(
@@ -30,7 +31,8 @@ class TwigExtensionFactory
             ));
         }
 
-        if (! $container->has(UrlHelper::class)
+        if (
+            ! $container->has(UrlHelper::class)
             && ! $container->has(\Zend\Expressive\Helper\UrlHelper::class)
         ) {
             throw new InvalidConfigException(sprintf(

--- a/src/TwigRenderer.php
+++ b/src/TwigRenderer.php
@@ -34,22 +34,16 @@ class TwigRenderer implements TemplateRendererInterface
     use ArrayParametersTrait;
     use DefaultParamsTrait;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     private $suffix;
 
-    /**
-     * @var FilesystemLoader
-     */
+    /** @var FilesystemLoader */
     protected $twigLoader;
 
-    /**
-     * @var Environment
-     */
+    /** @var Environment */
     protected $template;
 
-    public function __construct(Environment $template = null, string $suffix = 'html')
+    public function __construct(?Environment $template = null, string $suffix = 'html')
     {
         if (null === $template) {
             $template = $this->createTemplate($this->getDefaultLoader());
@@ -69,12 +63,8 @@ class TwigRenderer implements TemplateRendererInterface
 
     /**
      * Create a default Twig environment
-     *
-     * @param FilesystemLoader $loader
-     *
-     * @return Environment
      */
-    private function createTemplate(FilesystemLoader $loader) : Environment
+    private function createTemplate(FilesystemLoader $loader): Environment
     {
         return new Environment($loader);
     }
@@ -82,7 +72,7 @@ class TwigRenderer implements TemplateRendererInterface
     /**
      * Get the default loader for template
      */
-    private function getDefaultLoader() : FilesystemLoader
+    private function getDefaultLoader(): FilesystemLoader
     {
         return new FilesystemLoader();
     }
@@ -90,20 +80,17 @@ class TwigRenderer implements TemplateRendererInterface
     /**
      * Render
      *
-     * @param string       $name
      * @param array|object $params
-     *
-     * @return string
      * @throws LoaderError
      * @throws RuntimeError
      * @throws SyntaxError
      */
-    public function render(string $name, $params = []) : string
+    public function render(string $name, $params = []): string
     {
         // Merge parameters based on requested template name
         $params = $this->mergeParams($name, $this->normalizeParams($params));
 
-        $name   = $this->normalizeTemplate($name);
+        $name = $this->normalizeTemplate($name);
 
         // Merge parameters based on normalized template name
         $params = $this->mergeParams($name, $params);
@@ -114,12 +101,9 @@ class TwigRenderer implements TemplateRendererInterface
     /**
      * Add a path for template
      *
-     * @param string      $path
-     * @param string|null $namespace
-     *
      * @throws LoaderError
      */
-    public function addPath(string $path, string $namespace = null) : void
+    public function addPath(string $path, ?string $namespace = null): void
     {
         $namespace = $namespace ?: FilesystemLoader::MAIN_NAMESPACE;
         $this->twigLoader->addPath($path, $namespace);
@@ -130,11 +114,11 @@ class TwigRenderer implements TemplateRendererInterface
      *
      * @return TemplatePath[]
      */
-    public function getPaths() : array
+    public function getPaths(): array
     {
         $paths = [];
         foreach ($this->twigLoader->getNamespaces() as $namespace) {
-            $name = ($namespace !== FilesystemLoader::MAIN_NAMESPACE) ? $namespace : null;
+            $name = $namespace !== FilesystemLoader::MAIN_NAMESPACE ? $namespace : null;
 
             foreach ($this->twigLoader->getPaths($namespace) as $path) {
                 $paths[] = new TemplatePath($path, $name);
@@ -148,12 +132,8 @@ class TwigRenderer implements TemplateRendererInterface
      *
      * Normalizes templates in the format "namespace::template" to
      * "@namespace/template".
-     *
-     * @param string $template
-     *
-     * @return string
      */
-    public function normalizeTemplate(string $template) : string
+    public function normalizeTemplate(string $template): string
     {
         $template = preg_replace('#^([^:]+)::(.*)$#', '@$1/$2', $template);
         if (! preg_match('#\.[a-z]+$#i', $template)) {

--- a/src/TwigRendererFactory.php
+++ b/src/TwigRendererFactory.php
@@ -32,10 +32,9 @@ class TwigRendererFactory
 {
     /**
      * @throws LoaderError
-     * @throws Exception\InvalidConfigException if a non-array, non-ArrayObject
-     *     $config is received.
+     * @throws Exception\InvalidConfigException
      */
-    public function __invoke(ContainerInterface $container) : TwigRenderer
+    public function __invoke(ContainerInterface $container): TwigRenderer
     {
         $config      = $container->has('config') ? $container->get('config') : [];
         $config      = self::mergeConfig($config);
@@ -52,10 +51,9 @@ class TwigRendererFactory
      * array having precedence.
      *
      * @param array|ArrayObject $config
-     * @throws Exception\InvalidConfigException if a non-array, non-ArrayObject
-     *     $config is received.
+     * @throws Exception\InvalidConfigException
      */
-    public static function mergeConfig($config) : array
+    public static function mergeConfig($config): array
     {
         $config = $config instanceof ArrayObject ? $config->getArrayCopy() : $config;
 
@@ -69,7 +67,7 @@ class TwigRendererFactory
         $mezzioConfig = isset($config['templates']) && is_array($config['templates'])
             ? $config['templates']
             : [];
-        $twigConfig       = isset($config['twig']) && is_array($config['twig'])
+        $twigConfig   = isset($config['twig']) && is_array($config['twig'])
             ? $config['twig']
             : [];
 
@@ -88,7 +86,7 @@ class TwigRendererFactory
      *
      * @throws LoaderError
      */
-    private function getEnvironment(ContainerInterface $container) : Environment
+    private function getEnvironment(ContainerInterface $container): Environment
     {
         if ($container->has(Environment::class)) {
             return $container->get(Environment::class);
@@ -97,7 +95,7 @@ class TwigRendererFactory
         trigger_error(sprintf(
             '%s now expects you to register the factory %s for the service %s; '
             . 'please update your dependency configuration.',
-            __CLASS__,
+            self::class,
             TwigEnvironmentFactory::class,
             Environment::class
         ), E_USER_DEPRECATED);

--- a/test/ConfigProviderTest.php
+++ b/test/ConfigProviderTest.php
@@ -15,17 +15,15 @@ use PHPUnit\Framework\TestCase;
 
 class ConfigProviderTest extends TestCase
 {
-    /**
-     * @var ConfigProvider
-     */
+    /** @var ConfigProvider */
     private $provider;
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->provider = new ConfigProvider();
     }
 
-    public function testInvocationReturnsArray() : array
+    public function testInvocationReturnsArray(): array
     {
         $config = ($this->provider)();
         $this->assertIsArray($config);
@@ -35,10 +33,8 @@ class ConfigProviderTest extends TestCase
 
     /**
      * @depends testInvocationReturnsArray
-     *
-     * @param array $config
      */
-    public function testReturnedArrayContainsDependencies(array $config) : void
+    public function testReturnedArrayContainsDependencies(array $config): void
     {
         $this->assertArrayHasKey('dependencies', $config);
         $this->assertArrayHasKey('templates', $config);

--- a/test/ExceptionTest.php
+++ b/test/ExceptionTest.php
@@ -23,12 +23,12 @@ use function substr;
 
 class ExceptionTest extends TestCase
 {
-    public function testExceptionInterfaceExtendsTemplateExceptionInterface() : void
+    public function testExceptionInterfaceExtendsTemplateExceptionInterface(): void
     {
         $this->assertTrue(is_a(ExceptionInterface::class, TemplateExceptionInterface::class, true));
     }
 
-    public function exception() : Generator
+    public function exception(): Generator
     {
         $namespace = substr(ExceptionInterface::class, 0, strrpos(ExceptionInterface::class, '\\') + 1);
 
@@ -42,10 +42,8 @@ class ExceptionTest extends TestCase
 
     /**
      * @dataProvider exception
-     *
-     * @param string $exception
      */
-    public function testExceptionIsInstanceOfExceptionInterface(string $exception) : void
+    public function testExceptionIsInstanceOfExceptionInterface(string $exception): void
     {
         $this->assertStringContainsString('Exception', $exception);
         $this->assertTrue(is_a($exception, ExceptionInterface::class, true));

--- a/test/TwigExtensionFactoryTest.php
+++ b/test/TwigExtensionFactoryTest.php
@@ -23,22 +23,16 @@ use function sprintf;
 
 class TwigExtensionFactoryTest extends TestCase
 {
-    /**
-     * @var ContainerInterface|MockObject
-     */
+    /** @var ContainerInterface|MockObject */
     private $container;
 
-    /**
-     * @var ServerUrlHelper|MockObject
-     */
+    /** @var ServerUrlHelper|MockObject */
     private $serverUrlHelper;
 
-    /**
-     * @var UrlHelper|MockObject
-     */
+    /** @var UrlHelper|MockObject */
     private $urlHelper;
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->container       = $this->createMock(ContainerInterface::class);
         $this->serverUrlHelper = $this->createMock(ServerUrlHelper::class);

--- a/test/TwigExtensionFunctionsRenderTest.php
+++ b/test/TwigExtensionFunctionsRenderTest.php
@@ -25,7 +25,7 @@ class TwigExtensionFunctionsRenderTest extends TestCase
     protected $serverUrlHelper;
     protected $urlHelper;
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->twigLoader      = $this->createMock(LoaderInterface::class);
         $this->serverUrlHelper = $this->createMock(ServerUrlHelper::class);
@@ -87,10 +87,10 @@ class TwigExtensionFunctionsRenderTest extends TestCase
         $this->assertSame('PATH', $twig->render('template'));
     }
 
-    public function renderPathProvider()
+    public function renderPathProvider(): array
     {
         return [
-            'path'                => [
+            'path'                   => [
                 "{{ path('route', {'foo': 'bar'}) }}",
                 'route',
                 ['foo' => 'bar'],
@@ -98,7 +98,7 @@ class TwigExtensionFunctionsRenderTest extends TestCase
                 null,
                 [],
             ],
-            'path-query'          => [
+            'path-query'             => [
                 "{{ path('path-query', {'id': '3'}, {'foo': 'bar'}) }}",
                 'path-query',
                 ['id' => 3],
@@ -106,7 +106,7 @@ class TwigExtensionFunctionsRenderTest extends TestCase
                 null,
                 [],
             ],
-            'path-query-fragment' => [
+            'path-query-fragment'    => [
                 "{{ path('path-query-fragment', {'foo': 'bar'}, {'qux': 'quux'}, 'corge') }}",
                 'path-query-fragment',
                 ['foo' => 'bar'],
@@ -114,7 +114,7 @@ class TwigExtensionFunctionsRenderTest extends TestCase
                 'corge',
                 [],
             ],
-            'path-reuse-result' => [
+            'path-reuse-result'      => [
                 "{{ path('path-query-fragment', {}, {}, null, {'reuse_result_params': true}) }}",
                 'path-query-fragment',
                 [],
@@ -161,10 +161,10 @@ class TwigExtensionFunctionsRenderTest extends TestCase
         $this->assertSame('HOST/PATH', $twig->render('template'));
     }
 
-    public function renderUrlProvider()
+    public function renderUrlProvider(): array
     {
         return [
-            'path'                => [
+            'path'                   => [
                 "{{ url('route', {'foo': 'bar'}) }}",
                 'route',
                 ['foo' => 'bar'],
@@ -172,7 +172,7 @@ class TwigExtensionFunctionsRenderTest extends TestCase
                 null,
                 [],
             ],
-            'path-query'          => [
+            'path-query'             => [
                 "{{ url('path-query', {'id': '3'}, {'foo': 'bar'}) }}",
                 'path-query',
                 ['id' => 3],
@@ -180,7 +180,7 @@ class TwigExtensionFunctionsRenderTest extends TestCase
                 null,
                 [],
             ],
-            'path-query-fragment' => [
+            'path-query-fragment'    => [
                 "{{ url('path-query-fragment', {'foo': 'bar'}, {'qux': 'quux'}, 'corge') }}",
                 'path-query-fragment',
                 ['foo' => 'bar'],
@@ -188,7 +188,7 @@ class TwigExtensionFunctionsRenderTest extends TestCase
                 'corge',
                 [],
             ],
-            'path-reuse-result' => [
+            'path-reuse-result'      => [
                 "{{ url('path-query-fragment', {}, {}, null, {'reuse_result_params': true}) }}",
                 'path-query-fragment',
                 [],

--- a/test/TwigExtensionFunctionsRenderTest.php
+++ b/test/TwigExtensionFunctionsRenderTest.php
@@ -27,9 +27,9 @@ class TwigExtensionFunctionsRenderTest extends TestCase
 
     protected function setUp() : void
     {
-        $this->twigLoader      = $this->prophesize(LoaderInterface::class);
-        $this->serverUrlHelper = $this->prophesize(ServerUrlHelper::class);
-        $this->urlHelper       = $this->prophesize(UrlHelper::class);
+        $this->twigLoader      = $this->createMock(LoaderInterface::class);
+        $this->serverUrlHelper = $this->createMock(ServerUrlHelper::class);
+        $this->urlHelper       = $this->createMock(UrlHelper::class);
 
         $this->templates = [
             'template' => "{{ path('route') }}",
@@ -47,8 +47,8 @@ class TwigExtensionFunctionsRenderTest extends TestCase
 
         $twig = new Environment($loader, ['debug' => true, 'cache' => false]);
         $twig->addExtension(new TwigExtension(
-            $this->serverUrlHelper->reveal(),
-            $this->urlHelper->reveal(),
+            $this->serverUrlHelper,
+            $this->urlHelper,
             $assetsUrl,
             $assetsVersion
         ));
@@ -78,7 +78,10 @@ class TwigExtensionFunctionsRenderTest extends TestCase
             'template' => $template,
         ];
 
-        $this->urlHelper->generate($route, $routeParams, $queryParams, $fragment, $options)->willReturn('PATH');
+        $this->urlHelper
+            ->method('generate')
+            ->with($route, $routeParams, $queryParams, $fragment, $options)
+            ->willReturn('PATH');
         $twig = $this->getTwigEnvironment();
 
         $this->assertSame('PATH', $twig->render('template'));
@@ -145,8 +148,14 @@ class TwigExtensionFunctionsRenderTest extends TestCase
             'template' => $template,
         ];
 
-        $this->urlHelper->generate($route, $routeParams, $queryParams, $fragment, $options)->willReturn('PATH');
-        $this->serverUrlHelper->generate('PATH')->willReturn('HOST/PATH');
+        $this->urlHelper
+            ->method('generate')
+            ->with($route, $routeParams, $queryParams, $fragment, $options)
+            ->willReturn('PATH');
+        $this->serverUrlHelper
+            ->method('generate')
+            ->with('PATH')
+            ->willReturn('HOST/PATH');
         $twig = $this->getTwigEnvironment();
 
         $this->assertSame('HOST/PATH', $twig->render('template'));
@@ -204,7 +213,11 @@ class TwigExtensionFunctionsRenderTest extends TestCase
             'template' => "{{ absolute_url('path/to/something') }}",
         ];
 
-        $this->serverUrlHelper->generate('path/to/something')->willReturn('HOST/PATH');
+        $this->serverUrlHelper
+            ->method('generate')
+            ->with('path/to/something')
+            ->willReturn('HOST/PATH');
+
         $twig = $this->getTwigEnvironment();
 
         $this->assertSame('HOST/PATH', $twig->render('template'));

--- a/test/TwigExtensionTest.php
+++ b/test/TwigExtensionTest.php
@@ -19,6 +19,9 @@ use Twig\TwigFunction;
 
 use function sprintf;
 
+/**
+ * phpcs:disable WebimpressCodingStandard.Functions.Param.MissingSpecification
+ */
 class TwigExtensionTest extends TestCase
 {
     /** @var ServerUrlHelper|MockObject */
@@ -27,13 +30,13 @@ class TwigExtensionTest extends TestCase
     /** @var UrlHelper|MockObject */
     private $urlHelper;
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->serverUrlHelper = $this->createMock(ServerUrlHelper::class);
-        $this->urlHelper = $this->createMock(UrlHelper::class);
+        $this->urlHelper       = $this->createMock(UrlHelper::class);
     }
 
-    public function createExtension($assetsUrl, $assetsVersion)
+    public function createExtension($assetsUrl, $assetsVersion): TwigExtension
     {
         return new TwigExtension(
             $this->serverUrlHelper,
@@ -43,6 +46,7 @@ class TwigExtensionTest extends TestCase
         );
     }
 
+    /** @return object|bool */
     public function findFunction($name, array $functions)
     {
         foreach ($functions as $function) {
@@ -147,7 +151,7 @@ class TwigExtensionTest extends TestCase
         );
     }
 
-    public function emptyAssetVersions()
+    public function emptyAssetVersions(): array
     {
         return [
             'null'         => [null],
@@ -157,7 +161,6 @@ class TwigExtensionTest extends TestCase
 
     /**
      * @dataProvider emptyAssetVersions
-     *
      * @param null|string $emptyValue
      */
     public function testRenderAssetUrlWithoutProvidedVersion($emptyValue)
@@ -169,7 +172,7 @@ class TwigExtensionTest extends TestCase
         );
     }
 
-    public function zeroAssetVersions()
+    public function zeroAssetVersions(): array
     {
         return [
             'zero'        => [0],
@@ -179,7 +182,6 @@ class TwigExtensionTest extends TestCase
 
     /**
      * @dataProvider zeroAssetVersions
-     *
      * @param int|string $zeroValue
      */
     public function testRendersZeroVersionAssetUrl($zeroValue)

--- a/test/TwigRendererFactoryTest.php
+++ b/test/TwigRendererFactoryTest.php
@@ -30,25 +30,24 @@ use function sprintf;
 
 use const E_USER_DEPRECATED;
 
+/**
+ * phpcs:disable WebimpressCodingStandard.Functions.Param.MissingSpecification
+ */
 class TwigRendererFactoryTest extends TestCase
 {
-    /**
-     * @var ContainerInterface|MockObject
-     */
+    /** @var ContainerInterface|MockObject */
     private $container;
 
-    /**
-     * @var callable
-     */
+    /** @var callable */
     private $errorHandler;
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->restoreErrorHandler();
         $this->container = $this->createMock(ContainerInterface::class);
     }
 
-    protected function tearDown() : void
+    protected function tearDown(): void
     {
         $this->restoreErrorHandler();
     }
@@ -61,7 +60,7 @@ class TwigRendererFactoryTest extends TestCase
         }
     }
 
-    public function fetchTwigEnvironment(TwigRenderer $twig)
+    public function fetchTwigEnvironment(TwigRenderer $twig): Environment
     {
         $r = new ReflectionProperty($twig, 'template');
         $r->setAccessible(true);
@@ -69,7 +68,7 @@ class TwigRendererFactoryTest extends TestCase
         return $r->getValue($twig);
     }
 
-    public function getConfigurationPaths()
+    public function getConfigurationPaths(): array
     {
         return [
             'foo' => __DIR__ . '/TestAsset/bar',
@@ -128,7 +127,7 @@ class TwigRendererFactoryTest extends TestCase
         $this->assertContains($expected, $found, $message);
     }
 
-    public function testCallingFactoryWithNoConfigReturnsTwigInstance()
+    public function testCallingFactoryWithNoConfigReturnsTwigInstance(): TwigRenderer
     {
         $this->container
             ->expects($this->any())
@@ -158,8 +157,6 @@ class TwigRendererFactoryTest extends TestCase
 
     /**
      * @depends testCallingFactoryWithNoConfigReturnsTwigInstance
-     *
-     * @param TwigRenderer $twig
      */
     public function testUnconfiguredTwigInstanceContainsNoPaths(TwigRenderer $twig)
     {
@@ -263,16 +260,16 @@ class TwigRendererFactoryTest extends TestCase
         $config = [
             'templates' => [
                 'extension' => 'file extension used by templates; defaults to html.twig',
-                'paths' => [],
+                'paths'     => [],
             ],
-            'twig' => [
-                'cache_dir' => 'path to cached templates',
-                'assets_url' => 'base URL for assets',
-                'assets_version' => 'base version for assets',
-                'extensions' => [],
+            'twig'      => [
+                'cache_dir'       => 'path to cached templates',
+                'assets_url'      => 'base URL for assets',
+                'assets_version'  => 'base version for assets',
+                'extensions'      => [],
                 'runtime_loaders' => [],
-                'globals' => ['ga_tracking' => 'UA-XXXXX-X'],
-                'timezone' => 'default timezone identifier, e.g.: America/New_York',
+                'globals'         => ['ga_tracking' => 'UA-XXXXX-X'],
+                'timezone'        => 'default timezone identifier, e.g.: America/New_York',
             ],
         ];
 

--- a/test/TwigRendererTest.php
+++ b/test/TwigRendererTest.php
@@ -24,19 +24,18 @@ use function str_replace;
 use function uniqid;
 use function var_export;
 
+/**
+ * phpcs:disable WebimpressCodingStandard.Functions.Param.MissingSpecification
+ */
 class TwigRendererTest extends TestCase
 {
-    /**
-     * @var FilesystemLoader
-     */
+    /** @var FilesystemLoader */
     private $twigFilesystem;
 
-    /**
-     * @var Environment
-     */
+    /** @var Environment */
     private $twigEnvironment;
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->twigFilesystem  = new FilesystemLoader();
         $this->twigEnvironment = new Environment($this->twigFilesystem);
@@ -72,7 +71,8 @@ class TwigRendererTest extends TestCase
     public function assertEqualTemplatePath(TemplatePath $expected, TemplatePath $received, $message = null)
     {
         $message = $message ?: 'Failed to assert TemplatePaths are equal';
-        if ($expected->getPath() !== $received->getPath()
+        if (
+            $expected->getPath() !== $received->getPath()
             || $expected->getNamespace() !== $received->getNamespace()
         ) {
             $this->fail($message);
@@ -121,15 +121,15 @@ class TwigRendererTest extends TestCase
     {
         $renderer = new TwigRenderer();
         $renderer->addPath(__DIR__ . '/TestAsset');
-        $name = 'Twig';
-        $result = $renderer->render('twig.html', [ 'name' => $name ]);
+        $name   = 'Twig';
+        $result = $renderer->render('twig.html', ['name' => $name]);
         $this->assertStringContainsString($name, $result);
         $content = file_get_contents(__DIR__ . '/TestAsset/twig.html');
         $content = str_replace('{{ name }}', $name, $content);
         $this->assertEquals($content, $result);
     }
 
-    public function invalidParameterValues()
+    public function invalidParameterValues(): array
     {
         return [
             'true'       => [true],
@@ -144,7 +144,6 @@ class TwigRendererTest extends TestCase
 
     /**
      * @dataProvider invalidParameterValues
-     *
      * @param mixed $params
      */
     public function testRenderRaisesExceptionForInvalidParameterTypes($params)
@@ -158,12 +157,12 @@ class TwigRendererTest extends TestCase
     {
         $renderer = new TwigRenderer();
         $renderer->addPath(__DIR__ . '/TestAsset');
-        $result = $renderer->render('twig-null.html', null);
+        $result  = $renderer->render('twig-null.html', null);
         $content = file_get_contents(__DIR__ . '/TestAsset/twig-null.html');
         $this->assertEquals($content, $result);
     }
 
-    public function objectParameterValues()
+    public function objectParameterValues(): array
     {
         $names = [
             'stdClass'    => uniqid(),
@@ -178,7 +177,6 @@ class TwigRendererTest extends TestCase
 
     /**
      * @dataProvider objectParameterValues
-     *
      * @param object $params
      * @param string $search
      */
@@ -240,12 +238,12 @@ class TwigRendererTest extends TestCase
         $renderer->addPath(__DIR__ . '/TestAsset');
         $name = 'Twig';
         $renderer->addDefaultParam($renderer::TEMPLATE_ALL, 'name', $name);
-        $result = $renderer->render('twig');
+        $result  = $renderer->render('twig');
         $content = file_get_contents(__DIR__ . '/TestAsset/twig.html');
         $content = str_replace('{{ name }}', $name, $content);
         $this->assertEquals($content, $result);
 
-        $result = $renderer->render('twig-2');
+        $result  = $renderer->render('twig-2');
         $content = file_get_contents(__DIR__ . '/TestAsset/twig-2.html');
         $content = str_replace('{{ name }}', $name, $content);
         $this->assertEquals($content, $result);
@@ -255,16 +253,16 @@ class TwigRendererTest extends TestCase
     {
         $renderer = new TwigRenderer();
         $renderer->addPath(__DIR__ . '/TestAsset');
-        $name = 'Twig';
+        $name  = 'Twig';
         $name2 = 'Template';
         $renderer->addDefaultParam($renderer::TEMPLATE_ALL, 'name', $name);
         $renderer->addDefaultParam('twig-2', 'name', $name2);
-        $result = $renderer->render('twig');
+        $result  = $renderer->render('twig');
         $content = file_get_contents(__DIR__ . '/TestAsset/twig.html');
         $content = str_replace('{{ name }}', $name, $content);
         $this->assertEquals($content, $result);
 
-        $result = $renderer->render('twig-2');
+        $result  = $renderer->render('twig-2');
         $content = file_get_contents(__DIR__ . '/TestAsset/twig-2.html');
         $content = str_replace('{{ name }}', $name2, $content);
         $this->assertEquals($content, $result);
@@ -274,10 +272,10 @@ class TwigRendererTest extends TestCase
     {
         $renderer = new TwigRenderer();
         $renderer->addPath(__DIR__ . '/TestAsset');
-        $name = 'Twig';
+        $name  = 'Twig';
         $name2 = 'Template';
         $renderer->addDefaultParam($renderer::TEMPLATE_ALL, 'name', $name);
-        $result = $renderer->render('twig', ['name' => $name2]);
+        $result  = $renderer->render('twig', ['name' => $name2]);
         $content = file_get_contents(__DIR__ . '/TestAsset/twig.html');
         $content = str_replace('{{ name }}', $name2, $content);
         $this->assertEquals($content, $result);


### PR DESCRIPTION
- Update PHP constraint to ^7.3 || ~8.0.0
- Update PHPUnit constraint to ^9.3
- Remove constraint for phpspec/prophecy
- Update Travis job matrix to cover 7.3, 7.4, and 8.0
- Migrate tests from Prophecy to PHPUnit mocks
- Update coding standard constraint to ~2.1.0 and applies it to the code base

Fixes #4