### PR TITLE
Update Twig link in readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://github.com/mezzio/mezzio-twigrenderer/actions/workflows/continuous-integration.yml/badge.svg)](https://github.com/mezzio/mezzio-twigrenderer/actions/workflows/continuous-integration.yml)
 
-Provides [Twig](http://twig.sensiolabs.org/) integration for
+Provides [Twig](https://twig.symfony.com/) integration for
 [Mezzio](https://docs.laminas.dev//mezzio/).
 
 ## Installation


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes

### Description

This PR fixes the broken link to the Twig homepage in the README.